### PR TITLE
fix: handle PDF page image conversion errors before encoding PNG output

### DIFF
--- a/.changeset/fair-pdfium-render.md
+++ b/.changeset/fair-pdfium-render.md
@@ -1,0 +1,5 @@
+---
+"@craftlions/pdfium-rs": patch
+---
+
+Handle PDF page image conversion errors before encoding rendered PNG output.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,7 +57,8 @@ pub fn pdf_to_png(env: Env, bytes: Buffer) -> Result<Buffer> {
     let dyn_img = page
         .render_with_config(&render_config)
         .map_err(|e| Error::from_reason(format!("Render error: {:?}", e)))?
-        .as_image();
+        .as_image()
+        .map_err(|e| Error::from_reason(format!("Render image error: {:?}", e)))?;
 
     let mut buf = Vec::new();
     dyn_img


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Catch PDF page image conversion errors in `pdf_to_png` and return a clear error before PNG encoding, preventing crashes and unclear failures.

- **Bug Fixes**
  - Map image conversion failures to a descriptive "Render image error: ..." instead of failing during PNG encoding.
  - Add a patch changeset for `@craftlions/pdfium-rs`.

<sup>Written for commit 72571b9916505209e040319171b846c7ee2a0653. Summary will update on new commits. <a href="https://cubic.dev/pr/craftlions/rs/pull/57?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

